### PR TITLE
Update endpoint to a live API

### DIFF
--- a/modules/processor/src/main/resources/application.conf
+++ b/modules/processor/src/main/resources/application.conf
@@ -11,6 +11,6 @@ processor {
   }
 
   enrichmentConfig {
-    baseEndpoint = "https://restcountries.eu/rest/v2/name/"
+    baseEndpoint = "https://restcountries.com/v2/name/"
   }
 }


### PR DESCRIPTION
Tried running locally, the consumer example couldn't finish processing because the "restcountries.eu" endpoint isn't working anymore. The API at [restcountries.com](https://restcountries.com) is a working alternative, and is [compatible with the previous one](https://gitlab.com/amatos/rest-countries#important-information-about-version-2).